### PR TITLE
Fix PhotoSwipe lightbox with View Transitions

### DIFF
--- a/src/components/Gallery.astro
+++ b/src/components/Gallery.astro
@@ -49,10 +49,15 @@ const { images, id = Math.random().toString(), context = 'The Blonding Room' } =
   import PhotoSwipeLightbox from 'photoswipe/lightbox'
   import 'photoswipe/style.css'
 
-  const lightbox = new PhotoSwipeLightbox({
-    gallery: '.pswp-gallery',
-    children: 'a',
-    pswpModule: () => import('photoswipe'),
-  })
-  lightbox.init()
+  function initLightbox() {
+    const lightbox = new PhotoSwipeLightbox({
+      gallery: '.pswp-gallery',
+      children: 'a',
+      pswpModule: () => import('photoswipe'),
+    })
+    lightbox.init()
+  }
+
+  // Re-initialize after View Transitions swap the DOM
+  document.addEventListener('astro:page-load', initLightbox)
 </script>


### PR DESCRIPTION
## Summary
- PhotoSwipe lightbox click handlers were not being attached after Astro View Transitions (`ClientRouter`) swapped the DOM
- Wrapped PhotoSwipe initialization in `astro:page-load` event listener, which fires on initial load and after every view transition

## Test plan
- [ ] Verify lightbox opens when clicking gallery images on the homepage
- [ ] Verify lightbox works on all three galleries (salon, hair, staff) and the team group photo
- [ ] Navigate to a subpage and back, confirm lightbox still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)